### PR TITLE
Mint GitHub App token in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -16,12 +16,18 @@ jobs:
         if: |
           (!(github.event.head_commit.message == 'Update package version'))
         steps:
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                app-id: ${{ secrets.APP_ID }}
+                private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout repo
               uses: actions/checkout@v4
               with:
                 repository: ${{ github.event.pull_request.head.repo.full_name }}
                 ref: ${{ github.event.pull_request.head.ref }}
-                token: ${{ secrets.POLICYENGINE_GITHUB }}
+                token: ${{ steps.app-token.outputs.token }}
             - name: Setup Python
               uses: actions/setup-python@v5
               with:
@@ -35,6 +41,8 @@ jobs:
               with:
                 add: "."
                 message: Update package version
+                github_token: ${{ steps.app-token.outputs.token }}
+                fetch: false
     publish-to-pypi:
       name: Publish to PyPI
       if: (github.event.head_commit.message == 'Update package version')

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Versioning workflow now mints a GitHub App token instead of using the expired POLICYENGINE_GITHUB PAT.


### PR DESCRIPTION
## Summary
- Org PAT `POLICYENGINE_GITHUB` expired 2026-01-12; switch the versioning workflow to mint a GitHub App token via `actions/create-github-app-token@v1` using `APP_ID` + `APP_PRIVATE_KEY`.
- Pass the minted token to the `actions/checkout@v4` step and the `EndBug/add-and-commit@v9` step (with `fetch: false`) so the auto-commit back to `main` is authenticated.
- Matches the migrations already merged in `microdf` (#296) and `policyengine-core` (#470).

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI green on this PR.
- [ ] After merge: next changelog-entry-bearing PR merging to `main` successfully triggers the Versioning workflow and opens an auto-commit "Update package version".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>